### PR TITLE
Extract Groonga::Log::Parser from fluent-plugin-groonga-log

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,2 +1,14 @@
 require "bundler/gem_tasks"
 task :default => :spec
+
+desc "Run tests"
+task :test do
+  task_index = ARGV.index("test")
+  if task_index
+    run_test_options = ARGV[(task_index + 1)..-1]
+  else
+    run_test_options = []
+  end
+  tests_exit_status = ruby("test/run-test.rb", *run_test_options)
+  exit(tests_exit_status)
+end

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require "bundler/gem_tasks"
-task :default => :spec
+task :default => :test
 
 desc "Run tests"
 task :test do

--- a/groonga-log.gemspec
+++ b/groonga-log.gemspec
@@ -46,4 +46,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"
+
+  spec.add_development_dependency("test-unit")
+  spec.add_development_dependency("test-unit-notify")
 end

--- a/groonga-log.gemspec
+++ b/groonga-log.gemspec
@@ -18,7 +18,7 @@
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'groonga/log/version'
+require 'groonga-log/version'
 
 clean_white_space = lambda do |entry|
   entry.gsub(/(\A\n+|\n+\z)/, '') + "\n"
@@ -26,7 +26,7 @@ end
 
 Gem::Specification.new do |spec|
   spec.name          = "groonga-log"
-  spec.version       = Groonga::Log::VERSION
+  spec.version       = GroongaLog::VERSION
 
   spec.authors       = ["Horimoto Yasuhiro"]
   spec.email         = ["horimoto@clear-code.com"]

--- a/lib/groonga-log.rb
+++ b/lib/groonga-log.rb
@@ -1,0 +1,2 @@
+require "groonga-log/version"
+require "groonga-log/parser"

--- a/lib/groonga-log/parser.rb
+++ b/lib/groonga-log/parser.rb
@@ -1,0 +1,84 @@
+# Copyright (C) 2017 Yasuhiro Horimoto <horimoto@clear-code.com>
+# Copyright (C) 2017 Kentaro Hayashi <hayashi@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+module GroongaLog
+  class Parser
+    PATTERN =
+      /\A(?<year>\d{4})-(?<month>\d\d)-(?<day>\d\d) (?<hour>\d\d):(?<minutes>\d\d):(?<seconds>\d\d)\.(?<micro_seconds>\d+)\|(?<log_level>.)\|(?<context_id>.+?)\|(?<message>.*)/
+
+    def parse(input)
+      return to_enum(:parse, input) unless block_given?
+
+      input.each_line do |line|
+        next unless line.valid_encoding?
+        m = PATTERN.match(line)
+
+        year = Integer(m['year'])
+        month = Integer(m['month'])
+        day = Integer(m['day'])
+        hour = Integer(m['hour'])
+        minutes = Integer(m['minutes'])
+        seconds = Integer(m['seconds'])
+        micro_seconds = Integer(m['micro_seconds'])
+        log_level = log_level_to_symbol(m['log_level'])
+        context_id = m['context_id']
+        message = m['message']
+        timestamp = Time.local(year, month, day,
+                               hour, minutes, seconds, micro_seconds)
+
+        record = {
+          :timestamp => timestamp,
+          :year => year,
+          :month => month,
+          :day => day,
+          :hour => hour,
+          :minutes => minutes,
+          :seconds => seconds,
+          :micro_seconds => micro_seconds,
+          :log_level => log_level,
+          :context_id => context_id,
+          :message => message,
+        }
+        yield record
+      end
+    end
+
+    private
+    def log_level_to_symbol(level_text)
+      case level_text
+      when "E"
+        :emergency
+      when "A"
+        :alert
+      when "C"
+        :critical
+      when "e"
+        :error
+      when "w"
+        :warning
+      when "n"
+        :notice
+      when "i"
+        :information
+      when "d"
+        :debug
+      when "-"
+        :dump
+      end
+    end
+  end
+end

--- a/lib/groonga-log/version.rb
+++ b/lib/groonga-log/version.rb
@@ -1,0 +1,3 @@
+module GroongaLog
+  VERSION = "0.1.0"
+end

--- a/lib/groonga/log.rb
+++ b/lib/groonga/log.rb
@@ -1,7 +1,0 @@
-require "groonga/log/version"
-
-module Groonga
-  module Log
-    # Your code goes here...
-  end
-end

--- a/lib/groonga/log/version.rb
+++ b/lib/groonga/log/version.rb
@@ -1,5 +1,0 @@
-module Groonga
-  module Log
-    VERSION = "0.1.0"
-  end
-end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,0 +1,17 @@
+# Copyright (C) 2017 Kentaro Hayashi <hayashi@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "groonga-log"

--- a/test/run-test.rb
+++ b/test/run-test.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+#
+# Copyright (C) 2012-2013  Kouhei Sutou <kou@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+$VERBOSE = true
+
+require "pathname"
+
+base_dir = Pathname.new(__FILE__).dirname.parent.expand_path
+top_dir = base_dir.parent
+
+lib_dir = base_dir + "lib"
+test_dir = base_dir + "test"
+
+require "test-unit"
+require "test/unit/notify"
+
+Test::Unit::Priority.enable
+
+$LOAD_PATH.unshift(lib_dir.to_s)
+
+$LOAD_PATH.unshift(test_dir.to_s)
+require "helper"
+
+Dir.glob("#{base_dir}/test/**/test{_,-}*.rb") do |file|
+  require file.sub(/\.rb\z/, '')
+end
+
+ENV["TEST_UNIT_MAX_DIFF_TARGET_STRING_SIZE"] ||= "5000"
+
+exit Test::Unit::AutoRunner.run

--- a/test/test-parser.rb
+++ b/test/test-parser.rb
@@ -1,0 +1,75 @@
+# Copyright (C) 2017 Yasuhiro Horimoto <horimoto@clear-code.com>
+# Copyright (C) 2017 Kentaro Hayashi <hayashi@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+require "helper"
+
+class ParserTest < Test::Unit::TestCase
+  def test_extract_field
+    expected = [{
+      :timestamp => Time.local(2017, 7, 19, 14, 41, 5, 663978),
+      :year => 2017,
+      :month => 7,
+      :day => 19,
+      :hour => 14,
+      :minutes => 41,
+      :seconds => 5,
+      :micro_seconds => 663978,
+      :log_level => :notice,
+      :context_id => "18c61700",
+      :message => "spec:2:update:Object:32(type):8",
+    }]
+    statistics = parse(<<-LOG)
+2017-07-19 14:41:05.663978|n|18c61700|spec:2:update:Object:32(type):8
+    LOG
+    assert_equal(expected, statistics)
+  end
+
+  def test_log_level
+    expected = [
+      :emergency,
+      :alert,
+      :critical,
+      :error,
+      :warning,
+      :notice,
+      :information,
+      :debug,
+      :dump
+    ]
+    statistics = parse(<<-LOG)
+2017-07-19 14:41:05.663978|E|18c61700|emergency
+2017-07-19 14:41:06.663978|A|18c61700|alert
+2017-07-19 14:41:06.663978|C|18c61700|critical
+2017-07-19 14:41:06.663978|e|18c61700|error
+2017-07-19 14:41:06.663978|w|18c61700|warning
+2017-07-19 14:41:06.663978|n|18c61700|notice
+2017-07-19 14:41:06.663978|i|18c61700|information
+2017-07-19 14:41:06.663978|d|18c61700|debug
+2017-07-19 14:41:06.663978|-|18c61700|dump
+    LOG
+    log_levels = statistics.collect do |statistic|
+      statistic[:log_level]
+    end
+    assert_equal(expected, log_levels)
+  end
+
+  private
+  def parse(log)
+    parser = GroongaLog::Parser.new
+    parser.parse(log).to_a
+  end
+end


### PR DESCRIPTION
This PR is aimed to split fluent-plugin-groonga-log architecture into two parts.

1. fluent-plugin-groonga-log (use groonga-log parser library)
2. groonga-log (provide parser as a library)